### PR TITLE
Add Slack PR notification workflows

### DIFF
--- a/.github/workflows/pr-closed-notify-slack.yml
+++ b/.github/workflows/pr-closed-notify-slack.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       !contains(github.event.pull_request.labels.*.name, 'dependencies') &&
+      !contains(github.event.pull_request.labels.*.name, 'ignore-for-release') &&
       github.event.pull_request.user.type != 'Bot'
 
     steps:

--- a/.github/workflows/pr-closed-notify-slack.yml
+++ b/.github/workflows/pr-closed-notify-slack.yml
@@ -1,0 +1,42 @@
+name: PR Closed — Notify Slack
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'dependencies') &&
+      github.event.pull_request.user.type != 'Bot'
+
+    steps:
+      - name: Post to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_CLOSED_WEBHOOK_URL }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_STATUS: ${{ github.event.pull_request.merged == true && 'merged' || 'closed' }}
+        run: |
+          PAYLOAD=$(jq -n \
+            --arg pr_url    "$PR_URL" \
+            --arg pr_status "$PR_STATUS" \
+            '{
+              pr_url:    $pr_url,
+              pr_status: $pr_status,
+            }')
+
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            --connect-timeout 10 \
+            --max-time 30 \
+            -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$PAYLOAD")
+
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "::error::Slack webhook failed (HTTP $HTTP_STATUS)"
+            exit 1
+          fi

--- a/.github/workflows/pr-in-review-notify-slack.yml
+++ b/.github/workflows/pr-in-review-notify-slack.yml
@@ -15,6 +15,7 @@ jobs:
     if: |
       !github.event.pull_request.draft &&
       !contains(github.event.pull_request.labels.*.name, 'dependencies') &&
+      !contains(github.event.pull_request.labels.*.name, 'ignore-for-release') &&
       github.event.requested_reviewer.type != 'Bot' &&
       github.event.review.user.type != 'Bot'
 

--- a/.github/workflows/pr-in-review-notify-slack.yml
+++ b/.github/workflows/pr-in-review-notify-slack.yml
@@ -1,0 +1,72 @@
+name: PR In Review — Notify Slack
+
+on:
+  pull_request:
+    types: [review_requested]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: |
+      !github.event.pull_request.draft &&
+      !contains(github.event.pull_request.labels.*.name, 'dependencies') &&
+      github.event.requested_reviewer.type != 'Bot' &&
+      github.event.review.user.type != 'Bot'
+
+    steps:
+      - name: Resolve PR reviewer → Slack user ID
+        id: slack
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_USER_REQUESTED: ${{ github.event.requested_reviewer.login }}
+          GITHUB_USER_REVIEWED: ${{ github.event.review.user.login }}
+          GITHUB_TO_SLACK: ${{ vars.SLACK_TO_GITHUB }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            GITHUB_USER="$GITHUB_USER_REQUESTED"
+          else
+            GITHUB_USER="$GITHUB_USER_REVIEWED"
+          fi
+
+          SLACK_ID=$(echo "$GITHUB_TO_SLACK" | jq -r --arg user "$GITHUB_USER" \
+            '.[] | select(.github == $user) | .slack')
+
+          if [ -z "$SLACK_ID" ]; then
+            echo "::warning::GitHub user '$GITHUB_USER' not found in SLACK_TO_GITHUB variable. Posting without Slack mention."
+          fi
+
+          echo "user_id=$SLACK_ID" >> $GITHUB_OUTPUT
+
+      - name: Post to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_REVIEW_WEBHOOK_URL }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_STATUS: ${{ github.event_name == 'pull_request' && 'review_requested' || github.event.review.state }}
+          SLACK_USER_ID: ${{ steps.slack.outputs.user_id }}
+        run: |
+          PAYLOAD=$(jq -n \
+            --arg pr_url      "$PR_URL" \
+            --arg pr_status   "$PR_STATUS" \
+            --arg pr_reviewer "$SLACK_USER_ID" \
+            '{
+              pr_url:      $pr_url,
+              pr_status:   $pr_status,
+              pr_reviewer: $pr_reviewer,
+            }')
+
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            --connect-timeout 10 \
+            --max-time 30 \
+            -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$PAYLOAD")
+
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "::error::Slack webhook failed (HTTP $HTTP_STATUS)"
+            exit 1
+          fi

--- a/.github/workflows/pr-opened-notify-slack.yml
+++ b/.github/workflows/pr-opened-notify-slack.yml
@@ -1,0 +1,96 @@
+name: PR Opened — Notify Slack
+
+on:
+  pull_request:
+    types: [ready_for_review, opened]
+
+# Minimum permissions needed
+permissions:
+  pull-requests: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    # Skip draft PRs and dependency bumps
+    if: |
+      !github.event.pull_request.draft &&
+      !contains(github.event.pull_request.labels.*.name, 'dependencies') &&
+      !contains(github.event.pull_request.labels.*.name, 'ignore-for-release') &&
+      github.event.pull_request.user.type != 'Bot'
+
+    steps:
+      - name: Extract Jira key
+        id: jira
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Try branch name first (RACK-XXXX-feature-description)
+          JIRA_KEY=$(echo "$BRANCH" | grep -oP 'RACK-\d+' | head -1)
+
+          # Fallback: scan PR body (template reminder at the bottom)
+          if [ -z "$JIRA_KEY" ]; then
+            JIRA_KEY=$(echo "$PR_BODY" | grep -oP 'RACK-\d+' | head -1)
+          fi
+
+          echo "key=$JIRA_KEY" >> $GITHUB_OUTPUT
+
+      - name: Resolve PR creator → Slack user ID
+        id: slack
+        env:
+          GITHUB_USER: ${{ github.event.pull_request.user.login }}
+          GITHUB_TO_SLACK: ${{ vars.SLACK_TO_GITHUB }}
+        run: |
+          SLACK_ID=$(echo "$GITHUB_TO_SLACK" | jq -r --arg user "$GITHUB_USER" \
+            '.[] | select(.github == $user) | .slack')
+
+          if [ -z "$SLACK_ID" ]; then
+            echo "::warning::GitHub user '$GITHUB_USER' not found in SLACK_TO_GITHUB variable. Posting without Slack mention."
+          fi
+
+          echo "user_id=$SLACK_ID" >> $GITHUB_OUTPUT
+
+      - name: Post to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_OPENED_WEBHOOK_URL }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          SLACK_USER_ID: ${{ steps.slack.outputs.user_id }}
+          JIRA_KEY: ${{ steps.jira.outputs.key }}
+        run: |
+          JIRA_ISSUE_URL="${JIRA_KEY:+https://vismarackbeat.atlassian.net/browse/$JIRA_KEY}"
+
+          PAYLOAD=$(jq -n \
+            --arg repo_name       "$REPO_NAME" \
+            --arg pr_title        "$PR_TITLE" \
+            --arg pr_body         "$PR_BODY" \
+            --arg pr_number       "$PR_NUMBER" \
+            --arg pr_url          "$PR_URL" \
+            --arg pr_creator      "$SLACK_USER_ID" \
+            --arg jira_key        "$JIRA_KEY" \
+            --arg jira_issue_url  "$JIRA_ISSUE_URL" \
+            '{
+              repo_name:      $repo_name,
+              pr_title:       $pr_title,
+              pr_body:        $pr_body,
+              pr_number:      $pr_number,
+              pr_url:         $pr_url,
+              pr_creator:     $pr_creator,
+              jira_key:       $jira_key,
+              jira_issue_url: $jira_issue_url,
+            }')
+
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            --connect-timeout 10 \
+            --max-time 30 \
+            -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$PAYLOAD")
+
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "::error::Slack webhook failed (HTTP $HTTP_STATUS)"
+            exit 1
+          fi


### PR DESCRIPTION
Adds the 3 Slack workflows for PR opened, in-review, and closed events. Uses org-level secrets/variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Slack notifications for pull request events, including when PRs are opened, sent for review, and closed. Notifications are intelligently filtered to exclude dependencies and bot activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->